### PR TITLE
Making OAuth not require a page refresh

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ let express = require('express');
 let path = require('path');
 let ejs = require('ejs');
 let request = require('request');
-let githubApi = require('./config/githubApi.json');
+let githubConfig = require('./config/githubApi.json');
+let session = require('express-session');
 const app = express();
 
 const github_client_id = process.env.GITHUB_CLIENT_ID || '';
@@ -19,7 +20,7 @@ const tokenPayload = {
   "client_secret": github_client_secret
 };
 const requestAccessTokenOptions = {
-  url: githubApi.githubTokenUrl,
+  url: githubConfig.githubTokenUrl,
   method: 'POST',
   json: true,
   headers: {
@@ -27,26 +28,43 @@ const requestAccessTokenOptions = {
   }
 };
 
-githubApi.githubAuthUrl += '?client_id=' + github_client_id
+githubConfig.githubAuthUrl += '?client_id=' + github_client_id
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.engine('ejs', ejs.renderFile);
+app.use(session({
+  secret: 'super secret keyboard cat'
+}));
 
 app.get('/', function (req, res) {
+  let origin = req.protocol + '://' + req.get('host');
+  let accessToken = req.session.accessToken || '';
+  let localGithubApi = Object.assign({}, githubConfig, {origin});
+  if (accessToken) {
+    localGithubApi.accessToken = accessToken;
+  }
+  res.render('index.ejs', localGithubApi);
+});
+
+app.get('/auth', function (req, res) {
+  let origin = req.protocol + '://' + req.get('host');
   let query = req.query;
   let code = query.code || '';
-  let localGithubApi = Object.assign({}, githubApi);
+  let accessToken = req.session.accessToken || '';
+  let data = Object.assign({accessToken:''}, {origin});
   if (code) {
     let payload = Object.assign({}, tokenPayload, { code });
     let opts = Object.assign({}, requestAccessTokenOptions, { body: payload});
     return request(opts, function (error, response, body) {
       if (!error && response.statusCode == 200) {
-        localGithubApi.accessToken = body.access_token;
+        accessToken = body.access_token;
+        req.session.accessToken = accessToken;
+        data.accessToken = accessToken;
       }
-      res.render('index.ejs', localGithubApi);
+      res.render('auth.ejs', data);
     });
   }
-  res.render('index.ejs', localGithubApi);
+  res.render('auth.ejs', data);
 });
 
 let port = process.env.PORT || 5000;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "ejs": "^2.4.2",
     "express": "^4.13.4",
+    "express-session": "^1.13.0",
     "request": "^2.72.0"
   }
 }

--- a/views/auth.ejs
+++ b/views/auth.ejs
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<link>
+<head>
+    <script>
+        window.addEventListener('message',function(event) {
+            let origin = event.origin;
+            if (event.origin !== '<%= origin %>') {
+                return;
+            }
+            event.source.postMessage('<%= accessToken %>', event.origin);
+        },false);
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <link>
+<head>
 <meta charset="utf-8">
 <meta http-equiv="x-ua-compatible" content="ie=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -88,7 +89,8 @@
     OctoShelf({
         initAccessToken: '<%= accessToken %>',
         initApiUrl: '<%= apiUrl %>',
-        initGithubUrl: '<%= githubUrl %>'
+        initGithubUrl: '<%= githubUrl %>',
+        origin: '<%= origin %>'
     });
 </script>
 </body>


### PR DESCRIPTION
It bothered me that adding an auth thoken required a full refresh.
Adding a `window.open` is pretty trivial, and makes for a much better
experience, so I didn't have a good excuse not to.

So here we are. I've added a new route, `/auth`, that takes in the
authentication callback from github and does a postMessage back
to the original window with the authToken.

I've also added the `origin` option that gets fed into `OctoShelf()`,
which passes in an origin for our `window.open()` call.

And finally, I am using `express-session` to store retrieved accessTokens
on `req.session`, so any/all page refreshes will come with an accessToken.