### PR TITLE
Documentation Updates, and UI overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Cool, me too! OctoShelf was built to solve this exact issue!
 In a nut-shell, OctoShelf can be seen as a multi-repo PR manager. It displays
 open pull requests, and can be refreshed as often as you like.
 
+OctoShelf is powered by:
+
+* [LocalStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage),
+* [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API),
+* [Notifications](https://developer.mozilla.org/en-US/docs/Web/API/notification),
+* and [Github's Awesome Api](https://developer.github.com/v3/)
+
 ## Usage
 
 To use OctoShelf you can either go [here](http://www.octoshelf.com/),
@@ -17,11 +24,11 @@ or you can fork and hack this project to meet your own use cases.
 
 With OctoShelf you can...
 
+* Add / Remove Repositories (persisted with localstorage)
 * Review the open pull requests of many repos at once
-* Add / Remove Repositories to localstorage
-* Check for new pull requests
-* Receive notifications when tabbed away
-* Point API calls to an enterprise account
+* Check for new pull requests (Managed by a background web worker)
+* Receive notifications when tabbed away (using Notifications API)
+* Point API calls to an enterprise account (see below)
 
 ## Running the App
 
@@ -32,14 +39,12 @@ npm install
 npm start
 ```
 
-And the webpage should be available on localhost:5000/
+And the webpage will be available on localhost:5000/
 
-If you want to customize OctoShelf (for Corp Github Accounts) you can change
-the following variables inside `config/githubApi.json`:
+If you want to customize OctoShelf update the following variables inside `config/config.json`:
 
 ```javascript
 {
-  "accessToken": "",    // You'll probably want this to be empty, but useful if you're using a personal access token
   "githubAuthUrl": "",  // Populate the github authentication url
   "githubTokenUrl": "", // Once youn finish authenticating with github, we'll hit this url to grab an access token
   "apiUrl": "",         // Github's API url. It may look a little different for enterprise hosts
@@ -47,24 +52,24 @@ the following variables inside `config/githubApi.json`:
 }
 ```
 
-You'll notice you have limited capabilities, and may hit Github's ratelimit rather quickly.
-To "fix" this, you have two options:
+You  may hit Github's api ratelimit rather quickly. To "fix" this, you have two options:
 
-* [Generate a public access token](https://github.com/settings/tokens/new), and fill the `accessToken` property in `githubApi.json`
+* [Generate a public access token](https://github.com/settings/tokens/new), and run the following:
+
+```
+PERSONAL_ACCESS_TOKEN=xxx npm start
+```
+
 * [Register a new OAuth Token](https://github.com/settings/applications/new), and run the following:
 
 ```
 GITHUB_CLIENT_ID=xxx GITHUB_CLIENT_SECRET=xxx npm start
 ```
 
+Personal access tokens and client_secret should be treated with the same level of security as a password.
 For more information, check out: https://developer.github.com/v3/oauth/
 
 ## Contributing
 
 I welcome any and all forms of contributions. If you have a feature request, feel
 free to open a new issue, or better yet, open a new pull request yourself! :)
-
-## Potential Future Features
-
-- [ ] Server-side pages that persists saved repos
-- [ ] Progressive Web App?

--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,4 @@
 {
-  "accessToken": "",
   "githubAuthUrl": "https://github.com/login/oauth/authorize",
   "githubTokenUrl": "https://github.com/login/oauth/access_token",
   "apiUrl": "https://api.github.com",

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -3,11 +3,13 @@
 }
 
 html {background: #EFFEFF}
-html, body, main {height: 100%;padding: 0;margin: 0}
-h1 {color: #fff;display: inline;font-size: 1rem;margin: 0;vertical-align: middle;}
+html, body {height: 100%;padding: 0;margin: 0}
+main {min-height: 100%;padding: 0;margin: 0}
+body {font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial;}
+h1 {color: #fff;display: inline;font-size: 1.5rem;margin: 0;}
+p {margin: 0 0 1rem}
 a{ color: #fff}
 
-.app {font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial;}
 .prList {margin: 0;padding: 0}
 .prListItem {
     background: #fff;
@@ -167,46 +169,45 @@ a{ color: #fff}
 }
 .notification.fadeOut {opacity: 0}
 
-.infoPanel {background: #333;color:#fff;padding: 1rem;position: fixed; bottom: 0; right: 0;text-align: right}
+.infoPanel {
+    background: #333;
+    border-top:1px solid #ccc;
+    color:#fff;
+    min-height: 100%;
+    width:100%;
+    padding: 1rem;
+    text-align: left;
+    margin-top: -60px;
+}
 .infoPanel .octicon {vertical-align: middle}
-.infoPanel-actions {border-left: 1px solid #fff;padding-left: 0.5rem;margin-left: 0.5rem;}
+.infoPanel-actions {border-left: 1px solid #fff;padding-left: 0.5rem;margin-left: 0.5rem;position: relative}
+.infoPanel-topPanel {min-height: 3rem;}
 
-.moreInfo-wrapper {
-    cursor: pointer;
-    position: relative;
-}
-.moreInfo-content {
+.infoPanel-description,
+.infoPanel-example {
     background: rgba(255,255,255,0.9);
-    border: 1px solid #333;
-    border-radius: 50% 50% 0 50%;
     color: #333;
-    height: 0;
-    width: 0;
-    padding: 0;
-    overflow: hidden;
-    position: absolute;
-    bottom:1.5rem;
-    right: 1.5rem;
+    width: 100%;
+    padding: 1rem;
+    margin-bottom: 1rem;
     transition: all .5s ease;
-    text-align: center;
-
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
 }
-.moreInfo-wrapper:focus + .moreInfo-content {
-
-    z-index: 999;
-    padding: 2rem;
-    height: 300px;
-    width: 300px;
+.infoPanel-description {text-align: center;}
+.infoPanel-description a {color: #333;}
+.infoPanel-exampleCode {
+    border: 1px solid #ccc;
+    background: #fff;
+    padding: 1rem 0;
+    overflow: scroll;
 }
-.moreinfo-githubLink {color: #333;vertical-align: middle;align-self: flex-end;font-size:2rem;}
+.infoPanel-exampleCode-header {
+    margin: 0 1rem;
+}
+.highlight {background: rgba(255,255,0,0.5);padding: 0.5rem}
+.moreinfo-githubLink {color: #333;}
 
 .refreshRate_wrapper {
     cursor: pointer;
-    position: relative;
     text-align: left
 }
 .refreshRate_icon {transition: all .5s ease;}
@@ -244,37 +245,34 @@ a{ color: #fff}
 }
 .notification-wrapper:hover .notification-moreInfo {height: 2rem;padding: 5px;border: 1px solid #333;}
 
-@media (max-width: 600px) {
-    .app {padding: 0.5rem;}
-    .app-prompt,
-    .app-repositoriesWrapper,
-    .app-repositories {position: unset; display: block;height: unset; width: 100% !important;}
-    .bubble.bubble {
-        position: static;
-        transform: none !important;
-        width: 100% !important;
-        text-align: left;
-        border: 0;
-        height: unset;
-        margin-bottom: 1rem;
-        border-radius: 0;
-        padding: 1rem;
-    }
-    .bubble.bubble .repositoryInner {transform: none !important;}
-    .repo-title {margin-right: 1rem;width: inherit;}
-    .repository:after {display: none;}
-    .addRepoInput-wrapper {padding: 0}
-    .addRepoInput-prefix {display: inline-block;padding: 0.5rem;background: #eee}
-    .addRepoInput-input {}
-    .addRepoInput {margin: 0.5rem 0}
-    .action {margin: 0 10px 0 0}
 
+/* Inline Experience */
+.octoInline {padding: 0.5rem;}
+.octoInline .app-prompt,
+.octoInline .app-repositoriesWrapper,
+.octoInline .app-repositories {position: unset; display: block;height: unset !important; width: 100% !important;margin-bottom: 1rem;}
+.octoInline .bubble {
+    position: static;
+    transform: none !important;
+    width: 100% !important;
+    text-align: left;
+    border: 0;
+    height: unset;
+    margin-bottom: 1rem;
+    border-radius: 0;
+    padding: 1rem;
+}
+.octoInline .bubble .repositoryInner {transform: none !important;}
+.octoInline .repo-title {margin-right: 1rem;width: inherit;}
+.octoInline .repository:after {display: none;}
+.octoInline + .infoPanel {margin-top: 0rem;}
+
+@media (max-width: 600px) {
+    .tagline-githubPowered {display: none}
+    .infoPanel-steps {padding-left: 0.5rem;}
     .tokenNeeded-anchor:hover .tokenNeeded-content {left: 0;width: 100%;height: unset;}
-    .infoPanel {width: 100%;}
-    .moreInfo-wrapper:focus + .moreInfo-content {
-        width: 100%;
-        border-radius: 0;
-        right: 0;
-        bottom: 3em;
-    }
+}
+
+@media (max-width: 400px) {
+    .tagline {display: none}
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -2,18 +2,17 @@
 <html>
 <link>
 <head>
-<meta charset="utf-8">
-<meta http-equiv="x-ua-compatible" content="ie=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>OctoShelf</title>
-<link rel="stylesheet" type="text/css" href="./styles/octicons.css"></link>
-<link rel="stylesheet" type="text/css" href="./styles/style.css"></link>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OctoShelf</title>
+    <link rel="stylesheet" type="text/css" href="./styles/octicons.css"></link>
+    <link rel="stylesheet" type="text/css" href="./styles/style.css"></link>
 </head>
 <body>
-<main id="app" class="app">
+<main id="octoshelf" class="app">
     <section id="addSection" class="app-prompt">
         <form id="addRepoForm" class="bubble">
-            <h1>OctoShelf</h1>
             <div class="addRepoInput-wrapper">
                 <div class="addRepoInput-prefix"><%= githubUrl %></div>
                 <input type="text" id="addRepoInput" class="addRepoInput-input" placeholder="Repository Url" />
@@ -21,12 +20,12 @@
             <div>
                 <a href="#" id="syncAll" class="octicon octicon-sync"></a>
                 <% if(!accessToken) { %>
-                    <a href="<%= githubAuthUrl %>" id="authStatus" class="octicon octicon-alert tokenNeeded-anchor">
+                <a href="<%= githubAuthUrl %>" id="authStatus" class="octicon octicon-alert tokenNeeded-anchor">
                         <span class="tokenNeeded-content">
                             You are absolutely free to use this app without authenticating,
                             however GitHub ratelimits api calls of token-less users.
                         </span>
-                    </a>
+                </a>
                 <% } %>
             </div>
         </form>
@@ -35,13 +34,14 @@
         <section id="repoSection" class="app-repositories"></section>
     </section>
     <section id="notifications" class="notifications"></section>
-    <div class="infoPanel">
-        <span class="infoPanel-description">
-            A
+</main>
+<section class="infoPanel">
+    <section class="infoPanel-topPanel">
+        <span>
+            <h1>OctoShelf</h1><span class="tagline">, <span class="tagline-githubPowered">a
             <a href="https://github.com" class="octicon octicon-logo-github"></a>
-            powered
-            <span class="octicon octicon-git-pull-request"></span>
-            <span class="octicon octicon-dashboard"></span>
+            powered</span> pull request manager
+            </span>
         </span>
         <span class="infoPanel-actions">
             <span class="refreshRate_wrapper">
@@ -74,16 +74,50 @@
                 <a id="requestNotifications" href="#" class="octicon octicon-broadcast notification-button"></a>
                 <div class="notification-moreInfo">Allow Notifications?</div>
             </span>
-            <div class="octicon octicon-question moreInfo-wrapper" tabindex="1"></div>
-            <div class="moreInfo-content">
-                <h2>Welcome to OctoShelf!</h2>
-                This is a side-projected aimed at making it easier to manage pull requests
-                across multiple repositories. Feel free to make contributions or fork me.
-                <a class="octicon octicon-mark-github moreinfo-githubLink" href="https://github.com/TheIronDeveloper/octoshelf"></a>
-            </div>
+            <a href="#" id="toggleViewType" class="octicon octicon-three-bars toggleViewType"></a>
+            <a href="#" id="moreInfoToggle" class="octicon octicon-question moreInfo-toggle"></a>
         </span>
-    </div>
-</main>
+    </section>
+    <section id="infoPanelDescription" class="infoPanel-description">
+        <h2>Welcome to OctoShelf!</h2>
+        <p>OctoShelf is here to help you manage pull requests across multiple repositories.</p>
+        <p>OctoShelf is powered by <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage">LocalStorage</a>,
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API">WebWorkers</a>,
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/notification">Notifications</a>,
+            and <a href="https://developer.github.com/v3/">Github's Api</a>.</p>
+        <a class="mega-octicon octicon-mark-github moreinfo-githubLink" href="https://github.com/TheIronDeveloper/octoshelf"></a>
+    </section>
+    <section class="infoPanel-example">
+        <h2>Enterprise Usage</h2>
+        <p>If you want to use OctoShelf for public Github, you're in the right place!</p>
+        <p>But, lets say you want this on an enterprise account. All you need to do is fork this repo, and make two changes.</p>
+        <ol class="infoPanel-steps">
+            <li>
+                Update config to point to your enterprise endpoints
+    <pre class="infoPanel-exampleCode">
+    <h3 class="infoPanel-exampleCode-header">/config/githubApi.json</h3>
+    {
+      "githubAuthUrl":  "", // request github access url (redirects back to /auth)
+      "githubTokenUrl": "", // retrieves access_token (called from /auth?code=xxx)
+      "apiUrl":         "", // root github api urls
+      "githubUrl":      ""  // root github repository urls
+    }
+    </pre>
+            </li>
+            <li>
+                Start the app with a public access token or a clientId and clientSecret
+    <pre class="infoPanel-exampleCode">
+    <h3 class="infoPanel-exampleCode-header">Starting the App</h3>
+    <span class="highlight">PERSONAL_ACCESS_TOKEN</span>=xxx npm start
+
+     - or -
+
+    <span class="highlight">GITHUB_CLIENT_ID</span>=xxx <span class="highlight">GITHUB_CLIENT_SECRET</span>=xxx npm start
+    </pre>
+            </li>
+        </ol>
+    </section>
+</section>
 <script src="./scripts/octoshelf.js"></script>
 <script>
     OctoShelf({


### PR DESCRIPTION
This is a lot of changes, which is why I'm tossing it up as a pull
request to visualize and digest before merging. I've changed the
homepage so that it displays the OctoShelf UI on the top, and an
informative usage guide on the bottom.

The repository bubbles dynamically update themselves based on the
window height/width. They spread out as far as possible, and if the
window is too thin or short, then the inline-view kicks in.
Additionally, I've added a button to toggle the inline view.

The more info (?) button now simply scrolls the user downward to
view more info.

---

I removed the `accessToken` config. Having the config there at all
was encouraging bad habits.  Instead, a personal_access_token can
now get passed in as an environment variable:

```
PERSONAL_ACCESS_TOKEN=xxx npm start
```